### PR TITLE
Support promises during FB bootstrap and add missing $apply calls.

### DIFF
--- a/ngFacebook.js
+++ b/ngFacebook.js
@@ -71,6 +71,10 @@ angular.module('ngFacebook', [])
             $rootScope.$broadcast("fb."+event, response, FB);
           });
         });
+
+        // Make sure 'fb.auth.authResponseChange' fires even if the user is not logged in. A user 
+        // that is not logged in can still make facebook api calls.
+        $facebook.getLoginStatus();
       });
 
       /**
@@ -111,11 +115,7 @@ angular.module('ngFacebook', [])
         }
       }
       function complete_login_deferred(user_id, value) {
-        if (user_id === null) {
-          login_deferred.reject(value);
-        } else {
-          login_deferred.resolve(value);
-        }
+        login_deferred.resolve(value);
         login_deferred_completed = true;
         login_deferred_user_id = user_id;
       }
@@ -132,8 +132,8 @@ angular.module('ngFacebook', [])
           $facebook.setCache("connected", true);
           complete_login_deferred_if_req(response.authResponse.userID, FB);
         } else {
-          $facebook.setCache("connected", false);          
-          complete_login_deferred_if_req(null, response.status);
+          $facebook.setCache("connected", false);
+          complete_login_deferred_if_req(null, FB);
         }
       });
 


### PR DESCRIPTION
Hi,

I just started using your module, and overall I think it's great. Thanks for sharing it. However, there are a couple issues with it.

[1] Your current module does not support promises during FB init.

Example:
i. a controller sets up the following variable:

``` javascript
$scope.fbAlbumCoverUrl = $facebook.api("/" + albumId).then(function (response) {
    return $facebook.api("/" + response.cover_photo);
}).then(function (response) {
    return response.source;
});
```

This promise will be completed once the original login_deferred promise is completed:

``` javascript
      var login_deferred=$q.defer();

      $facebook.api = function () {
        var deferred=$q.defer();
        var args=arguments;
        args[args.length++] = function(response) {
          if(response.error)  deferred.reject(response.error);
          else                deferred.resolve(response);
        };

        return login_deferred.promise.then(function(FB) {
          FB.api.apply(FB, args);
          return deferred.promise;
        });
      };
```

ii. the result of this promise is made visible in the html page being loaded

``` html
<img ng-src="fbAlbumCoverUrl">
```

iii. however, once facebook inits the order of facebook event firing is:

a. fb.auth.login
b. fb.auth.authResponseChange 

When fb.aut.login is fired $facebook._reset_login_deferred is invoked and the original login_deferred promise is never resolved.

``` javascript
      $rootScope.$on("fb.auth.login", $facebook._reset_login_deferred);

      $facebook._reset_login_deferred = function() {
        $facebook.clearCache();
        login_deferred=$q.defer();
        login_deferred.id=login_deferred_id++;
      };
```

To fix this I'm rely only on the authResponseChange to detect both login and logout (avoids any ordering issues). I also handle promises made prior to receiving the first authResponseChange status update.

[2] You are missing some $apply invocations. In short, when chaining promises (same $scope.fbAlbumCoverUrl example above) and binding them to the DOM, every time an out of $digest cycle update happens - specifically facebook callback completions - the module needs to call $apply. Otherwise the final result will never be visible.

See the following for more info:
http://plnkr.co/edit/g5AnUK6oq2OBz7q2MEh7?p=preview
http://stackoverflow.com/questions/14246442/angularjs-promise-never-resolved-in-controller

[3] I also saw that you were completing the login_deferred promise multiple times. That appears not to be a best practice. So I've changed your code to avoid doing that.

See https://groups.google.com/forum/#!topic/angular/Oh3x9oFAtpU
"Your promise can modify the deferred `value`. This seems to be in violation of the standard that Promises are read-only. "

Let me know what you think of the changes.

Thanks.

Amir
