### PR TITLE
Fix FB.ui responses

### DIFF
--- a/ngFacebook.js
+++ b/ngFacebook.js
@@ -169,9 +169,11 @@ angular.module('ngFacebook', [])
 
         return $facebook.promise.then(function(FB) {
           FB.ui(params, function(response) {
-            if(response && response.post_id)     deferred.resolve(response);
-            else if (response && response.error) deferred.reject(response.error);
-            else                                 deferred.reject(null);
+            if(response && response.error_code) {
+              deferred.reject(response.error_message);
+            } else {
+              deferred.resolve(response);
+            }
             if(!$rootScope.$$phase) $rootScope.$apply();
           });
           return deferred.promise;


### PR DESCRIPTION
These changes works for sure in API v2.0 I don't know about older version. Otherwise we can't reach any promise success and fail response.
