### PR TITLE
add parameters to login() method in doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Using
 1. `$facebook.config(property)`   - Return the config property.
 1. `$facebook.getAuthResponse()`  - Return the `AuthResponse`(assuming you already connected)
 1. `$facebook.getLoginStatus()`   - Return *promise* of the result.
-1. `$facebook.login()`   - Logged in to your app by facebook. Return *promise* of the result.
+1. `$facebook.login(permissions, rerequest)`   - Logged in to your app by facebook. Return *promise* of the result.
 1. `$facebook.logout()`   - Logged out from facebook. Return *promise* of the result.
 1. `$facebook.ui(params)`   - Do UI action(see facebook sdk docs). Return *promise* of the result.
 1. `$facebook.api(args...)`   - Do API action(see facebook sdk docs). Return *promise* of the result.


### PR DESCRIPTION
I was wondering why one was only able to set permissions in config, like Facebook's SDK could.
Until I realized that it was already implemented.

Simple update to docs.