### PR TITLE
allow $facebook.api to work even when user is logged out

### DIFF
--- a/ngFacebook.js
+++ b/ngFacebook.js
@@ -145,9 +145,9 @@ angular.module('ngFacebook', [])
             if(response.error)  deferred.reject(response.error);
             else {
                 deferred.resolve(response);
-                if($facebook.isConnected()==null)
-                    $rootScope.$broadcast("fb.auth.authResponseChange", response, FB);
             }
+            if($facebook.isConnected()==null)
+                $rootScope.$broadcast("fb.auth.authResponseChange", response, FB);
             if(!$rootScope.$$phase) $rootScope.$apply();
           }, force);
           return deferred.promise;


### PR DESCRIPTION
* modified $facebook.getLoginStatus to always broadcast "fb.auth.authResponseChange" if user is not connected
discussed the issue further here: https://github.com/GoDisco/ngFacebook/issues/65
I'll be happy to modify any changes based on feedback.  Thanks!